### PR TITLE
chore(response): add created() to response helper methods

### DIFF
--- a/server/utils/response.js
+++ b/server/utils/response.js
@@ -48,6 +48,16 @@ export default (res) => {
     },
 
     /**
+     * Sends status 201 and `data` to the client
+     * Should be sent when something new has been created on the server
+     * 
+     * @param {*} data The data to send
+     */
+    created(data) {
+      this.sendData(201, data);
+    },
+
+    /**
     * Send data to the client.
     * 
     * @access private
@@ -55,7 +65,7 @@ export default (res) => {
     * @param {*} data 
     */
     sendData(status, data) {
-      if (typeof data === 'string') {
+      if (typeof data !== 'object') {
         data = {
           message: data,
         };

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -19,6 +19,8 @@ tags:
     url: "http://swagger.io"
 - name: "store"
   description: "Access to Petstore orders"
+- name: "article"
+  description: "Every thing relating to articles"
 schemes:
 - "https"
 paths:
@@ -48,6 +50,34 @@ paths:
       - petstore_auth:
         - "write:pets"
         - "read:pets"
+
+  /articles:
+    post:
+      tags:
+      - "article"
+      summary: "Creates a new article"
+      description: "Creates a new article"
+      consumes:
+        - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "article"
+        description: "Create an article"
+        required: true
+        schema:
+          type: "object"
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            body:
+              type: string
+      responses:
+        200:
+          description: "Success"
         
 securityDefinitions:
   petstore_auth:


### PR DESCRIPTION
#### What does this PR do?
Adds `created()` to response helpers methods for instances that has just been created.

#### How should this be manually tested?
1. Clone this branch.
2. Run `npm install` to install the dependencies.
3. Run `npm test` to run the tests.

#### What are the relevant pivotal tracker stories?
[#164198494](https://pivotaltracker.com/story/show/164198494)
