### PR TITLE
#164608984 add feature to get edit history for a comment

### DIFF
--- a/server/controllers/articleComment.js
+++ b/server/controllers/articleComment.js
@@ -213,10 +213,16 @@ class Comment {
         articleId: article.id, // This ensures the comment belongs to the specified article
         id: commentId
       },
-      attributes: ['comment', 'createdAt']
+      attributes: ['userId', 'comment', 'createdAt']
     });
     if (!comment) {
       return response(res).notFound('Comment does not exists');
+    }
+
+    const { user } = req;
+    // If user is not an admin AND is also not the persone that created the comment.
+    if (user.id !== comment.userId && !user.isAdmin) {
+      return response(res).unauthorized('You don\'t have permission to view this');
     }
 
     // Get comment history

--- a/server/controllers/articleComment.js
+++ b/server/controllers/articleComment.js
@@ -213,11 +213,18 @@ class Comment {
         articleId: article.id, // This ensures the comment belongs to the specified article
         id: commentId
       },
-      attributes: ['comment', 'createdAt']
+      attributes: ['userId', 'comment', 'createdAt']
     });
     if (!comment) {
       return response(res).notFound('Comment does not exists');
     }
+
+    const { user } = req;
+    // If user is not an admin AND is also not the persone that created the comment.
+    if (user.id !== comment.userId && !user.isAdmin) {
+      return response(res).unauthorized('You don\'t have permission to view this');
+    }
+    comment.userId = undefined; // user ID should not show in response.
 
     // Get comment history
     const dbHistory = await CommentEditHistory.findAll({

--- a/server/routes/articles.js
+++ b/server/routes/articles.js
@@ -81,7 +81,6 @@ router.delete('/articles/:slug/comment/:commentId',
 
 router.get('/articles/:slug/comment/:commentId/history',
   AuthenticateUser.verifyUser,
-  AuthenticateUser.isAdmin,
   AuthenticateArticle.verifyArticle,
   Comment.getEditHistory);
 

--- a/server/routes/articles.js
+++ b/server/routes/articles.js
@@ -79,4 +79,10 @@ router.delete('/articles/:slug/comment/:commentId',
   ValidateComment.validateComment,
   Comment.deleteComment);
 
+router.get('/articles/:slug/comment/:commentId/history',
+  AuthenticateUser.verifyUser,
+  AuthenticateUser.isAdmin,
+  AuthenticateArticle.verifyArticle,
+  Comment.getEditHistory);
+
 export default router;

--- a/server/test/commentEditHistory.spec.js
+++ b/server/test/commentEditHistory.spec.js
@@ -61,20 +61,6 @@ describe('Test endpoint to return edit history', () => {
       });
   });
 
-  it('should edit the above comment', (done) => {
-    chai
-      .request(app)
-      .patch(`/api/articles/${articleSlug}/comment/${commentId}`)
-      .set('authorization', `Bearer ${userToken}`)
-      .send({
-        comment: 'This is the edited version of the comment'
-      })
-      .end((err, res) => {
-        expect(res.status).to.equal(200);
-        done();
-      });
-  });
-
   it('should return a 401 if user trying to get edit history is not an admin', (done) => {
     chai
       .request(app)
@@ -86,7 +72,7 @@ describe('Test endpoint to return edit history', () => {
       });
   });
 
-  it('should return a 404 admin is trying to get history for a comment that does not exists', (done) => {
+  it('should return a 404 if user is trying to get history for a comment that does not exists', (done) => {
     chai
       .request(app)
       .get(`/api/articles/${articleSlug}/comment/9876545/history`)
@@ -97,7 +83,7 @@ describe('Test endpoint to return edit history', () => {
       });
   });
 
-  it('should get edit history of the comment of the article', (done) => {
+  it('should get edit history of the comment (if comment has not been editted)', (done) => {
     chai
       .request(app)
       .get(`/api/articles/${articleSlug}/comment/${commentId}/history`)
@@ -108,9 +94,22 @@ describe('Test endpoint to return edit history', () => {
         const { original, history } = res.body;
         expect(original.comment).to.be.a('string');
         expect(history).to.be.an('array');
-        expect(history.length).to.equal(1);
+        expect(history.length).to.equal(0);
         expect(original.comment).to.equal('This is original comment');
-        expect(history[0].comment).to.equal('This is the edited version of the comment');
+        done();
+      });
+  });
+
+  it('should edit the above comment', (done) => {
+    chai
+      .request(app)
+      .patch(`/api/articles/${articleSlug}/comment/${commentId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send({
+        comment: 'This is the edited version of the comment'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
         done();
       });
   });
@@ -129,7 +128,7 @@ describe('Test endpoint to return edit history', () => {
       });
   });
 
-  it('should get a edit history of the comment of the article after editting the comment the second time', (done) => {
+  it('should get edit history of the comment of the article.', (done) => {
     chai
       .request(app)
       .get(`/api/articles/${articleSlug}/comment/${commentId}/history`)

--- a/server/test/commentEditHistory.spec.js
+++ b/server/test/commentEditHistory.spec.js
@@ -1,0 +1,133 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import dotenv from 'dotenv';
+import app from '../app';
+
+dotenv.config();
+chai.use(chaiHttp);
+
+let userToken, adminToken, commentId;
+const articleSlug = 'this-is-an-article-1';
+
+describe('Test endpoint to return edit history', () => {
+  before('it should get admin user', (done) => {
+    chai
+      .request(app)
+      .post('/api/users/login')
+      .send({
+        name: process.env.SUPER_ADMIN_USERNAME,
+        password: process.env.SUPER_ADMIN_PASSWORD
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        const { token } = res.body.user;
+        adminToken = token;
+        done();
+      });
+  });
+
+  before('it should create a regular user', (done) => {
+    chai
+      .request(app)
+      .post('/api/users')
+      .send({
+        firstname: 'Comment',
+        lastname: 'Bot',
+        username: 'commentbot',
+        email: 'commentbot@authorshaven.com',
+        password: '1234567890'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(201);
+        const { token } = res.body.user;
+        userToken = token;
+        done();
+      });
+  });
+
+  it('should create a new comment', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${articleSlug}/comment`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send({
+        comment: 'This is original comment'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(201);
+        const { userComment } = res.body;
+        commentId = userComment.id;
+        done();
+      });
+  });
+
+  it('should edit the above comment', (done) => {
+    chai
+      .request(app)
+      .patch(`/api/articles/${articleSlug}/comment/${commentId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send({
+        comment: 'This is the edited version of the comment'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('should edit the above comment again', (done) => {
+    chai
+      .request(app)
+      .patch(`/api/articles/${articleSlug}/comment/${commentId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send({
+        comment: 'This is the second time the comment is editted'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('should return a 401 if user trying to get edit history is not an admin', (done) => {
+    chai
+      .request(app)
+      .get(`/api/articles/${articleSlug}/comment/${commentId}/history`)
+      .set('authorization', `bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(401);
+        done();
+      });
+  });
+
+  it('should return a 404 admin is trying to get history for a comment that does not exists', (done) => {
+    chai
+      .request(app)
+      .get(`/api/articles/${articleSlug}/comment/9876545/history`)
+      .set('authorization', `Bearer ${adminToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(404);
+        done();
+      });
+  });
+
+  it('should get a edit history of the comment of the article', (done) => {
+    chai
+      .request(app)
+      .get(`/api/articles/${articleSlug}/comment/${commentId}/history`)
+      .set('authorization', `bearer ${adminToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+
+        const { original, history } = res.body;
+        expect(original.comment).to.be.a('string');
+        expect(history).to.be.an('array');
+        expect(history.length).to.equal(2);
+        expect(original.comment).to.equal('This is original comment');
+        // History is sorted starting from most recent editted.
+        expect(history[0].comment).to.equal('This is the second time the comment is editted');
+        expect(history[1].comment).to.equal('This is the edited version of the comment');
+        done();
+      });
+  });
+});

--- a/server/test/commentEditHistory.spec.js
+++ b/server/test/commentEditHistory.spec.js
@@ -1,0 +1,151 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import dotenv from 'dotenv';
+import app from '../app';
+
+dotenv.config();
+chai.use(chaiHttp);
+
+let userToken, adminToken, commentId;
+const articleSlug = 'this-is-an-article-1';
+
+describe('Test endpoint to return edit history', () => {
+  before('it should get admin user', (done) => {
+    chai
+      .request(app)
+      .post('/api/users/login')
+      .send({
+        name: process.env.SUPER_ADMIN_USERNAME,
+        password: process.env.SUPER_ADMIN_PASSWORD
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        const { token } = res.body.user;
+        adminToken = token;
+        done();
+      });
+  });
+
+  before('it should create a regular user', (done) => {
+    chai
+      .request(app)
+      .post('/api/users')
+      .send({
+        firstname: 'Comment',
+        lastname: 'Bot',
+        username: 'commentbot',
+        email: 'commentbot@authorshaven.com',
+        password: '1234567890'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(201);
+        const { token } = res.body.user;
+        userToken = token;
+        done();
+      });
+  });
+
+  it('should create a new comment', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${articleSlug}/comment`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send({
+        comment: 'This is original comment'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(201);
+        const { userComment } = res.body;
+        commentId = userComment.id;
+        done();
+      });
+  });
+
+  it('should edit the above comment', (done) => {
+    chai
+      .request(app)
+      .patch(`/api/articles/${articleSlug}/comment/${commentId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send({
+        comment: 'This is the edited version of the comment'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('should return a 401 if user trying to get edit history is not an admin', (done) => {
+    chai
+      .request(app)
+      .get(`/api/articles/${articleSlug}/comment/${commentId}/history`)
+      .set('authorization', `bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(401);
+        done();
+      });
+  });
+
+  it('should return a 404 admin is trying to get history for a comment that does not exists', (done) => {
+    chai
+      .request(app)
+      .get(`/api/articles/${articleSlug}/comment/9876545/history`)
+      .set('authorization', `Bearer ${adminToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(404);
+        done();
+      });
+  });
+
+  it('should get edit history of the comment of the article', (done) => {
+    chai
+      .request(app)
+      .get(`/api/articles/${articleSlug}/comment/${commentId}/history`)
+      .set('authorization', `bearer ${adminToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+
+        const { original, history } = res.body;
+        expect(original.comment).to.be.a('string');
+        expect(history).to.be.an('array');
+        expect(history.length).to.equal(1);
+        expect(original.comment).to.equal('This is original comment');
+        expect(history[0].comment).to.equal('This is the edited version of the comment');
+        done();
+      });
+  });
+
+  it('should edit the above comment again', (done) => {
+    chai
+      .request(app)
+      .patch(`/api/articles/${articleSlug}/comment/${commentId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send({
+        comment: 'This is the second time the comment is editted'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('should get a edit history of the comment of the article after editting the comment the second time', (done) => {
+    chai
+      .request(app)
+      .get(`/api/articles/${articleSlug}/comment/${commentId}/history`)
+      .set('authorization', `bearer ${adminToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+
+        const { original, history } = res.body;
+        expect(original.comment).to.be.a('string');
+        expect(history).to.be.an('array');
+        expect(history.length).to.equal(2);
+        expect(original.comment).to.equal('This is original comment');
+        // History is sorted starting from most recent editted.
+        expect(history[0].comment).to.equal('This is the second time the comment is editted');
+        expect(history[1].comment).to.equal('This is the edited version of the comment');
+        done();
+      });
+  });
+});

--- a/server/test/index.js
+++ b/server/test/index.js
@@ -9,3 +9,4 @@ import './report.spec';
 import './articleSearch.spec';
 import './admin.spec';
 import './notification.spec';
+import './commentEditHistory.spec';


### PR DESCRIPTION
#### What does this PR do?
Add feature to get edit history for a comment

#### Description of Task to be completed?
- Created feature to get edit history of a comment.
  GET /api/articles/<slug>/comment/<comment-id>/history
  * Authorization required
  * Admin priviledge required
- Wrote tests

#### How should this be manually tested?
1. Clone this branch.
2. Run `npm install` to install the dependencies.
3. Run `npm test` to run the tests.

#### What are the relevant pivotal tracker stories?
[#164608984](https://pivotaltracker.com/story/show/164608984)